### PR TITLE
Ignore 'return' from update_uri_parameters

### DIFF
--- a/minik/fields.py
+++ b/minik/fields.py
@@ -77,6 +77,9 @@ def update_uri_parameters(view_fn, request):
     try:
 
         for field_name, field_type in view_fn.__annotations__.items():
+            field_name == 'return':
+                #  Ignore 'return' field_name if type hint exists for view_fn
+                continue
             new_field_type = CUSTOM_FIELD_BY_TYPE.get(field_type, field_type)
             values_by_name[field_name] = new_field_type(values_by_name[field_name])
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -86,3 +86,27 @@ def test_update_uri_parameters_basic_str():
         update_uri_parameters(sample_view, request)
     except MinikViewError as ve:
         assert 'sco!!' in str(ve)
+
+
+def test_update_uri_parameters_return_hint_is_ignored():
+    """
+    With a return type hint, only annotated parameter will be
+    accepted as valid.
+    """
+
+    def sample_view(bike_name: str) -> str:
+        return bike_name
+
+    request = MagicMock(uri_params={'bike_name': '5234'})
+    update_uri_parameters(sample_view, request)
+    assert request.uri_params['bike_name'] == str('5234')
+
+    request = MagicMock(uri_params={'bike_name': 'scott'})
+    update_uri_parameters(sample_view, request)
+    assert request.uri_params['bike_name'] == str('scott')
+
+    try:
+        request = MagicMock(uri_params={'bike_name': 'sco!!'})
+        update_uri_parameters(sample_view, request)
+    except MinikViewError as ve:
+        assert 'sco!!' in str(ve)


### PR DESCRIPTION
If type hints are added also as `return` of a function, `__annotations__` will get as `'return'` (per https://www.python.org/dev/peps/pep-3107/)
The field_name `'return'` should be ignored.

Added test for ignored return hints on `fields.update_uri_parameters`