### PR TITLE
Making a fix for query string spaces.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,14 @@
 Minik Changelog
 ===============
 
+Version 0.5.7
+-------------
+
+Released on Mar 21, 2020, codename Yeni Yil.II
+
+- Making a fix for query string spaces. Thanks to @andreburto for this contribution (pr/44)
+
+
 Version 0.5.6
 -------------
 

--- a/minik/__init__.py
+++ b/minik/__init__.py
@@ -5,4 +5,4 @@
     :license: Apache License, Version 2.0, see LICENSE for more details.
 """
 
-__version__ = '0.5.6'
+__version__ = '0.5.7'

--- a/minik/builders.py
+++ b/minik/builders.py
@@ -120,12 +120,14 @@ def url_decode_params(query_params):
     Decode the key value pairs of a set of parameters.
     """
 
-    def decode_string(key_or_value):
-        """ Use unquote_plus first to convert + into spaces. Then use unquote to decode any other encodings. """
+    def _decode_string(key_or_value):
+        """
+        Use unquote_plus first to convert + into spaces. Then use unquote to decode any other encodings.
+        """
         return urllib.parse.unquote(urllib.parse.unquote_plus(key_or_value))
 
     return {
-        decode_string(key): decode_string(value)
+        _decode_string(key): _decode_string(value)
         for key, value in query_params.items()
     }
 

--- a/minik/builders.py
+++ b/minik/builders.py
@@ -119,8 +119,13 @@ def url_decode_params(query_params):
     """
     Decode the key value pairs of a set of parameters.
     """
+
+    def decode_string(key_or_value):
+        """ Use unquote_plus first to convert + into spaces. Then use unquote to decode any other encodings. """
+        return urllib.parse.unquote(urllib.parse.unquote_plus(key_or_value))
+
     return {
-        urllib.parse.unquote(key): urllib.parse.unquote(value)
+        decode_string(key): decode_string(value)
         for key, value in query_params.items()
     }
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -26,3 +26,16 @@ class TestALBRequestBuilder:
         result = ALBRequestBuilder().build(alb_event, 'context', mock_router)
 
         assert result.query_params['foo[a]'] == 'foo['
+
+    def test_build_urldecodes_querystrings_with_spaces(self):
+
+        mock_router = MagicMock()
+        mock_router.resolve_path.return_value = ('resource', {})
+
+        alb_event = create_alb_event(path='/findme', queryParameters={'name': 'first+last',
+                                                                      'greeting': '%22Hello+world%2E%22'})
+
+        result = ALBRequestBuilder().build(alb_event, 'context', mock_router)
+
+        assert result.query_params['name'] == 'first last'
+        assert result.query_params['greeting'] == '"Hello world."'

--- a/tests/test_minik.py
+++ b/tests/test_minik.py
@@ -219,7 +219,6 @@ def test_empty_query_params():
     If there are no query parameters provided, the default value should be {}. The
     view should not throw an exception.
     """
-
     event = create_api_event('/empty_params', queryParameters=None)
 
     response = sample_app(event, context)


### PR DESCRIPTION
Within a GET query string spaces are encoded as plus signs (`?name=Andy+Burton`) and should be decoded into spaces when a request comes in. Currently `%20` is the only space character that is decoded.